### PR TITLE
Update compileSdk to 29

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
     ext.versions = [
-            'compileSdk'           : 'android-Q',
+            'compileSdk'           : 29,
             'minSdk'               : 21,
             'targetSdk'            : 29,
             'kotlin_version'       : '1.3.21',


### PR DESCRIPTION
I tried running this project but it failed with this error:

```
Failed to find Platform SDK with path: platforms;android-Q
```

Based on this https://developer.android.com/preview/setup-sdk, it seems using `29` is preferred for Android Q features.